### PR TITLE
fix(newsletter): add optional chaining to newsletter plugin properties

### DIFF
--- a/src/lib/components/common/newsletter.svelte
+++ b/src/lib/components/common/newsletter.svelte
@@ -52,8 +52,8 @@
 	{#snippet content({ loadingForSubmitting })}
 		<div class="flex flex-col gap-2 sm:gap-3">
 			<div class="space-y-1.5">
-				<h3 class="text-sm font-bold uppercase tracking-widest text-foreground">{plugin.heading || 'Newsletter'}</h3>
-				<p class="text-sm text-muted-foreground"> {plugin.subheading || 'Subscribe to get the latest arrivals and offers.'}</p>
+				<h3 class="text-sm font-bold uppercase tracking-widest text-foreground">{plugin?.heading || 'Newsletter'}</h3>
+				<p class="text-sm text-muted-foreground"> {plugin?.subheading || 'Subscribe to get the latest arrivals and offers.'}</p>
 			</div>
 
 			<form
@@ -66,7 +66,7 @@
 				<Input
 					type="email"
 					aria-label="Email address"
-					placeholder={plugin.placeholder || "Enter your email" }
+					placeholder={plugin?.placeholder || "Enter your email" }
 					bind:value={email}
 					class="h-10 w-full min-w-0 flex-1 bg-background"
 					required


### PR DESCRIPTION
### Summary
This PR adds optional chaining when reading properties from the `newsletter` plugin configuration object in `newsletter.svelte`.

### Problem
When the store data does not define a `newsletter` plugin object (`page.data.store?.plugins?.newsletter` is `undefined`), accessing `plugin.heading`, `plugin.subheading`, or `plugin.placeholder` causes an unhandled `TypeError: Cannot read properties of undefined` runtime error, which crashes the page rendering.

### Solution
Use optional chaining (`plugin?.heading`, `plugin?.subheading`, `plugin?.placeholder`) so that if the newsletter plugin object is undefined or missing, the component gracefully falls back to the default fallback values (`'Newsletter'`, `'Subscribe to get the latest arrivals and offers.'`, `"Enter your email"`).

### Changed Files
- `src/lib/components/common/newsletter.svelte`: Replaced direct property access on `plugin` with optional chaining (`plugin?.`).
